### PR TITLE
Use the default color for circled numbers by default.

### DIFF
--- a/circledsteps-manual.tex
+++ b/circledsteps-manual.tex
@@ -44,12 +44,13 @@ The basic commands are:
     \toprule
     Circled\{\} & circled text using the package colors, text on the baseline\\
     CircledTop\{\} & circled text using the package colors, circle on the baseline\\
-    CircledText\{\} & circled text using the current color (may fail\footnotemark{} in moving arguments)\\
+    CircledText\{\} & circled text using the current color (may fail\footnotemark{} across pages break in header or footers)\\
     \bottomrule
 \end{tabular}
 \footnotetext{in the sense it can select the wrong color.}
 
 The parameters for the output are controlled using \texttt{pgfkeys}; you can change them with \verb|\tikzset|; you can obviously limit the effect of change using normal \LaTeX{} scoping rules.
+The pseudo-color \texttt{none} means that the current color is used for both the text and the circle.
 
 \begin{tabular}{>{\ttfamily}lll}
     \toprule
@@ -57,8 +58,8 @@ The parameters for the output are controlled using \texttt{pgfkeys}; you can cha
     \midrule
     /csteps/inner ysep  & vertical spacing & 4pt\\
     /csteps/inner xsep  & horizontal spacing & 4pt\\
-    /csteps/inner color & color of the text  & red\\
-    /csteps/outer color & color of the circle & blue\\
+    /csteps/inner color & color of the text  & none\\
+    /csteps/outer color & color of the circle & none\\
     \bottomrule
 \end{tabular}
 
@@ -102,19 +103,23 @@ If you want to change colors it's easy:
 \par\bigskip
 \end{LTXexample}
 
+If you use the package option \texttt{redblue} or \texttt{legacy} you will have the same effect than
+
+\begin{lstlisting}[]
+    \tikzset{/csteps/inner color=red, /csteps/outer color=blue}
+\end{lstlisting}
+
 \begin{LTXexample}
 Or even you can have inline numbers like \CircledText{1} or
 exponents\textsuperscript{\CircledText{2}} and so on.
 \textcolor{red}{They follow the current color:  \CircledText{1} and \CircledText{2} automatically,} as you can see:  \CircledText{$1+1\approx3$}. In-text circled numbers look better when a bit smaller, though, as you can see in {\small\CircledText{1}} for example.
 \end{LTXexample}
 
-Notice that \verb|\CircledText{}| uses the special ``\texttt{.}'' color defined by \texttt{xcolor}; when page breaks occurs it can get the wrong color.
-
 No, you can't fill the circle/oval. Pull requests in that sense are welcome.
 
 \section{Automatically generated numbers}
 
-The command \verb|\cstep| will generate a circled number, starting from \texttt{1}, that can be referenced with the normal \verb|\label| mechanism. You can reset the numbering with 
+The command \verb|\cstep| will generate a circled number, starting from \texttt{1}, that can be referenced with the normal \verb|\label| mechanism. You can reset the numbering with
 \verb|\startcstep|. For example:
 
 \input{ctikzexample.tex}
@@ -125,12 +130,12 @@ The command \verb|\cstep| will generate a circled number, starting from \texttt{
 
 \section{Personalize it!}
 
-The definition of \verb|CircledTexT| is simply the following one; you can get idea and define your own easily (beware of spaces at the end of the lines, though!): 
+The definition of \verb|CircledTexT| is simply the following one; you can get idea and define your own easily (beware of spaces at the end of the lines, though!):
 
 \begin{lstlisting}
 \newcommand{\CircledText}[1]{%
     \begingroup
-    \tikzset{/csteps/inner color=., /csteps/outer color=.}%
+    \tikzset{/csteps/inner color=none, /csteps/outer color=none,}
     \Circled{#1}%
     \endgroup
 }
@@ -147,7 +152,7 @@ Also the implementation of the \verb|\cstep| command and relatives is quite simp
     \refstepcounter{cstepcnt}%
     \Circled{\scriptsize\arabic{cstepcnt}}%
 }
-\renewcommand{\thecstepcnt}{\textbf{\arabic{cstepcnt}:}}
+\renewcommand{\thecstepcnt}{\arabic{cstepcnt}}
 \end{lstlisting}
 
 

--- a/circledsteps.sty
+++ b/circledsteps.sty
@@ -1,6 +1,6 @@
 %    \begin{macrocode}
 \NeedsTeXFormat{LaTeX2e}[1996/06/01]
-\ProvidesPackage{circledsteps}[2019/06/19 v1.0 Circled steps that you can reference]
+\ProvidesPackage{circledsteps}[2019/11/01 v1.1 Circled steps that you can reference]
 %    \end{macrocode}
 %
 % Copyright (c) 2019 Romano Giannetti
@@ -14,12 +14,25 @@
 \RequirePackage{pgfkeys} % for the pgfkeys
 \pgfkeys{/csteps/inner ysep/.initial=4pt,
     /csteps/inner xsep/.initial=4pt,
-    /csteps/inner color/.initial=red,
-    /csteps/outer color/.initial=blue,
+    /csteps/inner color/.initial=none,
+    /csteps/outer color/.initial=none,
 }
+\DeclareOption{redblue}{
+    \tikzset{/csteps/inner color=red, /csteps/outer color=blue}%
+}
+\DeclareOption{legacy}{
+    \tikzset{/csteps/inner color=red, /csteps/outer color=blue}%
+}
+
+% end of options definitions
+\ProcessOptions\relax
+
 \newsavebox\csteps@CBox
 \newlength\csteps@XLength \newlength\csteps@YLength \newlength\csteps@YDepth \newlength\csteps@tmplen
 \def\csteps@CircledParam#1#2{\sbox\csteps@CBox{#2}%
+    \edef\csteps@none{none}%
+    \edef\csteps@outercolor{\pgfkeysvalueof{/csteps/outer color}}%
+    \edef\csteps@innercolor{\pgfkeysvalueof{/csteps/inner color}}%
     \csteps@XLength=\wd\csteps@CBox\advance\csteps@XLength by\pgfkeysvalueof{/csteps/inner xsep}\relax
     \csteps@tmplen=\pgfkeysvalueof{/csteps/inner ysep}\relax
     \csteps@YDepth=\dp\csteps@CBox\advance\csteps@YDepth by 0.5\csteps@tmplen\relax
@@ -29,18 +42,36 @@
     \ifdim\csteps@XLength>\csteps@YLength
     \makebox[\csteps@XLength]{% X bigger than Y
         \makebox(0,\csteps@YLength){%
-            \color{\pgfkeysvalueof{/csteps/outer color}}\put(0,0){\oval(\csteps@XLength,\csteps@YLength)}%
+            \ifx\csteps@outercolor\csteps@none\else
+                \color{\csteps@outercolor}%
+            \fi
+            \put(0,0){\oval(\csteps@XLength,\csteps@YLength)}%
         }%
     \makebox(0,\csteps@YLength){%
-        \put(-.5\wd\csteps@CBox,0){\textcolor{\pgfkeysvalueof{/csteps/inner color}}{#2}}%
+        \put(-.5\wd\csteps@CBox,0){%
+            \ifx\csteps@outercolor\csteps@none
+                #2\relax%
+            \else
+                \textcolor{\csteps@innercolor}{#2}%
+            \fi
+        }%
     }}%
     \else
     \makebox[\csteps@YLength]{%
         \makebox(0,\csteps@YLength){%
-            \color{\pgfkeysvalueof{/csteps/outer color}}\put(0,0){\circle{\csteps@YLength}}%
+            \ifx\csteps@outercolor\csteps@none\else
+                \color{\csteps@outercolor}%
+            \fi
+            \put(0,0){\circle{\csteps@YLength}}%
         }%
     \makebox(0,\csteps@YLength){%
-        \put(-.5\wd\csteps@CBox,0){\textcolor{\pgfkeysvalueof{/csteps/inner color}}{#2}}%
+        \put(-.5\wd\csteps@CBox,0){%
+            \ifx\csteps@outercolor\csteps@none
+                #2\relax%
+            \else
+                \textcolor{\csteps@innercolor}{#2}%
+            \fi
+        }%
      }}%
     \fi
     }%
@@ -52,7 +83,7 @@
 \def\CircledTop#1{\csteps@CircledParam{0}{#1}}
 \newcommand{\CircledText}[1]{%
     \begingroup
-    \tikzset{/csteps/inner color=., /csteps/outer color=.}%
+    \tikzset{/csteps/inner color=none, /csteps/outer color=none}%
     \Circled{#1}%
     \endgroup
 }
@@ -66,7 +97,7 @@
     \refstepcounter{cstepcnt}%
     \Circled{\scriptsize\arabic{cstepcnt}}%
 }
-\renewcommand{\thecstepcnt}{\textbf{\arabic{cstepcnt}:}}
+\renewcommand{\thecstepcnt}{\arabic{cstepcnt}}
 %    \end{macrocode}
 %
 %

--- a/ctikzexample.tex
+++ b/ctikzexample.tex
@@ -1,3 +1,5 @@
+\tikzset{/csteps/inner color=red, /csteps/outer color=blue}
+\newcommand{\circref}[1]{\CircledText{\small\textbf{\ref{#1}}}:}
 \begin{circuitikz}[scale=0.9, baseline=(VCC), transform shape]
     \draw (0,0)  node[ground](GND){} to[V=$v_s$] ++(0,2)
     to[R, l2^=$R_1$ and \SI{1}{k\ohm}, l2 valign=b] ++(2,0) coordinate(firstb);
@@ -19,9 +21,9 @@
 \begin{minipage}[t]{0.5\linewidth}
     %% minipage reset these..
     \parindent=0pt\parskip=6pt plus 6pt minus 2pt\relax
-    \ref{c:b1} let's neglect (to be confirmed!) $I_B$, $V_B\approx\SI{0}{V}$;\par
-    \ref{c:ie1} $I_{E1_Q}=(V_{E1_Q}-V_{EE})/R_3$;\par
-    \ref{c:ic1} $I_{C1_Q} \approx\SI{0.93}{mA}$;\par
-    \ref{c:g1} $V_{CC}-R_2I_{C2_Q}= \SI{5.35}{V}$; $V_{CE1_Q}=\SI{6.05}{V}$;\par
+    \circref{c:b1} let's neglect (to be confirmed!) $I_B$, $V_B\approx\SI{0}{V}$;\par
+    \circref{c:ie1} $I_{E1_Q}=(V_{E1_Q}-V_{EE})/R_3$;\par
+    \circref{c:ic1} $I_{C1_Q} \approx\SI{0.93}{mA}$;\par
+    \circref{c:g1} $V_{CC}-R_2I_{C2_Q}= \SI{5.35}{V}$; $V_{CE1_Q}=\SI{6.05}{V}$;\par
 \end{minipage}
 


### PR DESCRIPTION
This is to have a more "serious" look by default, see issue #1 on GitHub. An option will allow reverting back to the legacy (one week ago!) behavior.

Also, added a "none" pseudo color that is not issuing any color-changing command.

A preview of the manual is here: 
[circledsteps-manual.pdf](https://github.com/Rmano/circledsteps/files/3799007/circledsteps-manual.pdf)

Fixes #1