### PR TITLE
Handle two-column layouts

### DIFF
--- a/circledsteps.sty
+++ b/circledsteps.sty
@@ -87,12 +87,12 @@
         \makebox(0,\csteps@YLength){%
             \ifx\csteps@fillcolor\csteps@none\else
                 {\color{\csteps@fillcolor}%
-                \put(0,0){\circle*{\csteps@YLength}}}%
+                \put(0,0){\circle*{\strip@pt\csteps@YLength}}}%
             \fi
             \ifx\csteps@outercolor\csteps@none\else
                 \color{\csteps@outercolor}%
             \fi
-            \put(0,0){\circle{\csteps@YLength}}%
+            \put(0,0){\circle{\strip@pt\csteps@YLength}}%
         }%
     \makebox(0,\csteps@YLength){%
         \put(-.5\wd\csteps@CBox,0){%


### PR DESCRIPTION
The `\circle` command takes a number, not a length, but it is being passed a length.  Ordinarily that doesn't seem to make a difference, but it breaks on short text in a two-column book-chapter.  Here's the MWE:

```
\documentclass[twocolumn]{book}
\usepackage{circledsteps}
\begin{document}
\chapter{Required}
Doesn't work: \Circled{i} % too short!

Works: \Circled{long}
\end{document}
```

Compile it and you'll see an error in the logs from pict2e.

The fix here is to convert the length `\csteps@YLength` to a number, using `\strip@pt`.